### PR TITLE
[example] add invalid policies

### DIFF
--- a/demo.cedar
+++ b/demo.cedar
@@ -4,3 +4,25 @@ permit (
     action == Action::"View",
     resource is Document
 );
+
+// this policy is invalid because it contains an action that is not in the Cedar schema.
+permit (
+    principal,
+    action == Action::"Invalid",
+    resource is Document
+);
+
+// this policy is invalid because it contains a resource that is not in the Cedar schema.
+permit (
+    principal,
+    action == Action::"View",
+    resource is Invalid
+);
+
+// this policy is invalid because it contains an attribute that is not in the Cedar schema.
+permit (
+    principal,
+    action == Action::"View",
+    resource is Document
+)
+when { resource.foo == "bar" };


### PR DESCRIPTION
This PR is an example to show how our [Validate Cedar Policies](https://github.com/marketplace/actions/validate-cedar-policies) action creates annotations on a Pull Request. You can see the annotations in the ["Files Changed" view in this PR](https://github.com/common-fate/cedar-github-actions-testing-example/pull/1/files).